### PR TITLE
`get_index_from_point` accounting for Tilemap position

### DIFF
--- a/zero/ext/flx/FlxTilemapExt.hx
+++ b/zero/ext/flx/FlxTilemapExt.hx
@@ -15,7 +15,7 @@ class FlxTilemapExt
 	 * @param p point
 	 * @return Int
 	 */
-	public static inline function get_index_from_point(t:FlxTilemap, p:FlxPoint):Int return t.getTile((p.x / t.get_tile_width()).floor(), (p.y / t.get_tile_height()).floor());
+	public static inline function get_index_from_point(t:FlxTilemap, p:FlxPoint):Int return t.getTile(((p.x - t.x) / t.get_tile_width()).floor(), ((p.y - t.y) / t.get_tile_height()).floor());
 
 	/**
 	 * Returns a tile's allowCollisions value at a given point


### PR DESCRIPTION
This just edits the `get_index_from_point` method to work for Tilemaps that don't have a position of (0,0) 👍 