### PR TITLE
AStar - null safety when simplifying

### DIFF
--- a/zero/utilities/AStar.hx
+++ b/zero/utilities/AStar.hx
@@ -151,6 +151,7 @@ class AStar {
 	}
 
 	static function remove_nodes_on_path(points:Array<IntPoint>, map:Array<Array<Int>>):Array<IntPoint> {
+		if (points.length < 2) return points;
 		var last = points.shift();
 		var next = points.shift();
 		var v = next - last;
@@ -168,6 +169,7 @@ class AStar {
 	}
 
 	static function los_simplify(points:Array<IntPoint>, map:Array<Array<Int>>, passable:Array<Int>):Array<IntPoint> {
+		if (points.length < 2) return points;
 		var last = points.shift();
 		var current = points.shift();
 		var next = points.shift();
@@ -214,6 +216,7 @@ class AStar {
 	}
 
 	static function los_nd_simplify(points:Array<IntPoint>, map:Array<Array<Int>>, passable:Array<Int>):Array<IntPoint> {
+		if (points.length < 2) return points;
 		var last = points.shift();
 		var current = points.shift();
 		var next = points.shift();

--- a/zero/utilities/AStar.hx
+++ b/zero/utilities/AStar.hx
@@ -151,7 +151,7 @@ class AStar {
 	}
 
 	static function remove_nodes_on_path(points:Array<IntPoint>, map:Array<Array<Int>>):Array<IntPoint> {
-		if (points.length < 2) return points;
+		if (points.length < 3) return points;
 		var last = points.shift();
 		var next = points.shift();
 		var v = next - last;
@@ -169,7 +169,7 @@ class AStar {
 	}
 
 	static function los_simplify(points:Array<IntPoint>, map:Array<Array<Int>>, passable:Array<Int>):Array<IntPoint> {
-		if (points.length < 2) return points;
+		if (points.length < 3) return points;
 		var last = points.shift();
 		var current = points.shift();
 		var next = points.shift();
@@ -216,7 +216,7 @@ class AStar {
 	}
 
 	static function los_nd_simplify(points:Array<IntPoint>, map:Array<Array<Int>>, passable:Array<Int>):Array<IntPoint> {
-		if (points.length < 2) return points;
+		if (points.length < 3) return points;
 		var last = points.shift();
 		var current = points.shift();
 		var next = points.shift();


### PR DESCRIPTION
This PR just adds some null safety when a generated path that has less than 3 nodes is simplified.