### PR TITLE
add `in_circle` and `rad_between` methods to Vec2.hx

### DIFF
--- a/zero/utilities/Vec2.hx
+++ b/zero/utilities/Vec2.hx
@@ -89,10 +89,12 @@ abstract Vec2(Array<Float>)
 
 	public inline function copy():Vec2 return Vec2.get(x, y);
 	public inline function equals(v:Vec2):Bool return x == v.x && y == v.y;
+	public inline function in_circle(c:Vec2, r:Float):Bool return this.distance(c) < r;
 	public inline function dot(v:Vec2):Float return zero(x * v.x + y * v.y);
 	public inline function cross(v:Vec2):Float return zero(x * v.y - y * v.x);
 	public inline function facing(v:Vec2):Float return zero(x / length * v.x / v.length + y / length * v.y / v.length);
 	public inline function distance(v:Vec2):Float return (v - this).length;
+	public inline function rad_between(v:Vec2):Float return Math.atan2(v.y - y, v.x - x);
 	public inline function toString():String return 'x: $x | y: $y | length: $length | angle: $angle';
 
 	// Operator Overloads


### PR DESCRIPTION
Adds two methods to Vec2 - `in_circle` and `rad_between`.

`in_circle` is a quick way to check if a point is within the radius of a circle, defined by a vector for the center and a radius (the `c:Vec2` and `r:Float` arguments).

`rad_between` gets the radians between two vectors. its similar to `angle_between` in `zerolib.flixel.FlxPointExt`, but this doesn't assume you want the angle in degrees (since its easy enough to do like `var angle = v1.rad_between(v2).rad_to_deg();`